### PR TITLE
Add initial cookie consent

### DIFF
--- a/layouts/partials/cookie_consent.html
+++ b/layouts/partials/cookie_consent.html
@@ -1,0 +1,9 @@
+<div id="cookie_consent" class="cookie_consent">
+    <b>Cookie consent</b>
+    <p>This website uses cookies to ensure you get the best experience on our website.</p>
+    <hr>
+    <div class="buttons">
+        <button onclick="cookie_consent_accept()">Accept All</button>
+        <button onclick="cookie_consent_reject()">Reject All</button>
+    </div>
+</div>

--- a/static/css/cookie_consent.css
+++ b/static/css/cookie_consent.css
@@ -1,0 +1,25 @@
+.cookie_consent {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: #333;
+    color: #fff;
+    padding: 10px 20px;
+    text-align: center;
+    z-index: 1000;
+    box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.cookie_consent .buttons2 {
+    display: flex;
+    justify-content: space-between;
+}
+
+.cookie_consent .buttons button {
+    background-color: #999;
+    color: #333;
+    border: none;
+    padding: 5px 10px;
+    cursor: pointer;
+}

--- a/static/css/cookie_consent.css
+++ b/static/css/cookie_consent.css
@@ -1,4 +1,6 @@
 .cookie_consent {
+    /* Initially hidden, js will show if consent has not been given */
+    display: none;
     position: fixed;
     bottom: 0;
     left: 0;

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,6 +1,8 @@
 /* your styles go here */
 /* Example site test */
 
+@import url("cookie_consent.css");
+
 .box-image-text .image {
     min-height: 190px;
     max-height: 190px;

--- a/static/js/cookie_consent.js
+++ b/static/js/cookie_consent.js
@@ -1,0 +1,46 @@
+// Check for a cookie
+
+const cookie_consent_cookie_name = 'cookie_consent';
+const cookie_consent_id = 'cookie_consent';
+const cookie_consent_event = new Event('cookie_consent_given');
+
+// Return true if cookie consent has been given
+function cookie_consent_given() {
+    return document.cookie.indexOf(cookie_consent_cookie_name + '=accept') > -1;
+}
+
+// function called when document is loaded
+function cookie_consent_init() {
+    if (!cookie_consent_given()) {
+        document.getElementById(cookie_consent_id).style.display = 'block';
+    }
+}
+window.onload = cookie_consent_init;
+
+// Hide the cookie consent partial
+function cookie_consent_hide() {
+    document.getElementById(cookie_consent_id).style.display = 'none';
+
+}
+
+// Called when the user accepts the cookie consent
+function cookie_consent_accept() {
+    console.log('cookie_consent_accept');
+    document.cookie = 'cookie_consent=accept; expires=Fri, 31 Dec 9999 23:59:59 GMT';
+    document.getElementById(cookie_consent_id).dispatchEvent(cookie_consent_event);
+    cookie_consent_hide();
+}
+
+// Called when the user rejects the cookie consent
+function cookie_consent_reject() {
+    console.log('cookie_consent_decline');
+    // I believe you cannot store a cooke to say that we have rejected cookies
+    // So simply hide the cookie consent partial
+    cookie_consent_hide();
+}
+
+function cookie_consent_event_listener(fn) {
+    document.getElementById(cookie_consent_id).addEventListener('cookie_consent_given', function () {
+        fn();
+    });
+}

--- a/static/js/google_analytics.js
+++ b/static/js/google_analytics.js
@@ -1,0 +1,26 @@
+// Enable Google Analytics
+function enable_google_analytics() {
+    // Google tag (gtag.js)
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = 'https://www.googletagmanager.com/gtag/js?id=G-142HWTR609';
+    document.head.appendChild(script);
+
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-142HWTR609');
+}
+
+// Add an event listener for when the cookie consent changes
+cookie_consent_event_listener(() => {
+    if (cookie_consent_given()) {
+        enable_google_analytics();
+    }
+})
+
+
+// Check on startup to see if consent is already given
+if (cookie_consent_given()) {
+    enable_google_analytics();
+}

--- a/themes/hugo-universal-theme/layouts/index.html
+++ b/themes/hugo-universal-theme/layouts/index.html
@@ -31,6 +31,8 @@
     </div>
     <!-- /#all -->
 
+    {{ partial "cookie_consent.html" . }}
+
     {{ partial "scripts.html" . }}
 
   </body>

--- a/themes/hugo-universal-theme/layouts/partials/headers.html
+++ b/themes/hugo-universal-theme/layouts/partials/headers.html
@@ -1,14 +1,3 @@
-
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-142HWTR609"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-142HWTR609');
-</script>
-
 <meta charset="utf-8">
 <meta name="robots" content="all,follow">
 <meta name="googlebot" content="index,follow,snippet,archive">

--- a/themes/hugo-universal-theme/layouts/partials/scripts.html
+++ b/themes/hugo-universal-theme/layouts/partials/scripts.html
@@ -19,3 +19,7 @@
 <!-- owl carousel -->
 <script src="{{ "js/owl.carousel.min.js" | relURL }}"></script>
 
+<!-- Ensure cookie conset is loaded before anything that requires to check cookes -->
+<script src="{{ "js/cookie_consent.js" | relURL }}"></script>
+<script src="{{ "js/google_analytics.js" | relURL }}"></script>
+


### PR DESCRIPTION
Slight modification needed to the base template
- it would be nice if this could be done as a mixin so the template doesn't need to be modified...

The Google Analytics plugin is now loaded on demand when consent is given

Happy for anybody to change the styling, this is functional not pretty :o)

Signed-off-by: Matt Spencer matthew@thespencers.me.uk